### PR TITLE
Add event-specific Slack link

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -7,7 +7,7 @@ const Footer = () => {
       <div className="flex items-center gap-2 justify-center">
         <a href="https://hackclub.com" className="underline">Hack&nbsp;Club</a>
         <div className="w-[2px] h-3 bg-[#6D5C55]/40" />
-        <a href="https://hackclub.com/slack" className="underline">Slack</a>
+        <a href="https://hackclub.com/slack?event=The%20Boreal%20Express" className="underline">Slack</a>
         <div className="w-[2px] h-3 bg-[#6D5C55]/40" />
         <a href="https://www.youtube.com/@HackClubHQ" className="underline">YouTube</a>
         <div className="w-[2px] h-3 bg-[#6D5C55]/40" />


### PR DESCRIPTION
Just adds the `?event=` query param to the Slack invite to show the event name on the slack invite page like so:
![image](https://github.com/hackclub/boreal/assets/83948303/69dd0d2c-e0a8-4cd1-83bc-cb420e48899b)
